### PR TITLE
Add workflow_dispatch to README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Blueskyfeedbot is a bot that posts RSS feeds to Bluesky via GitHub Actions.
     on:
       schedule:
         # This will run every five minutes. Alter it using https://crontab.guru/.
-        - cron: '*/5 * * * *'  
+        - cron: '*/5 * * * *'
+      workflow_dispatch: # This allows manually running the workflow from the GitHub actions page
+    concurrency:
+      group: feedbot
     jobs:
       rss-to-bluesky:
         runs-on: ubuntu-latest


### PR DESCRIPTION
IMO it's nice to be able to immediately run the workflow via a workflow dispatch, so suggesting this change.

But feel free to reject.